### PR TITLE
Add the basic configuration for chat completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Gen-AI Training for Java Developers
+
+This project aims to help Java developers to understand the basic concepts of
+Generative AI and how to implement solutions using the Java language.
+
+## Project Setup
+1. Clone the repository.
+2. Edit your run configurations to add the following environment variables:
+   ```
+   OPEN_AI_KEY=<Your OpenAPI Key>
+   OPEN_AI_ENDPOINT=<Your OpenAPI Endpoint>
+   OPEN_AI_DEPLOYMENT_NAME=<The GPT Model >
+   ```
+3. Run the SpringBoot Application. The application would start on the port 8080 by default.
+
+### REST Endpoints
+- http://localhost:8080/api/chat-bot/simple-prompt?input=<Your-prompt>
+- http://localhost:8080/api/chat-bot/prompt-with-history?input=<Your-prompt>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.microsoft.semantic-kernel</groupId>
             <artifactId>semantickernel-experimental</artifactId>
-            <version>1.2.2</version>
+            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.semantic-kernel</groupId>

--- a/src/main/java/com/epam/training/gen/ai/GenAiTrainingApplication.java
+++ b/src/main/java/com/epam/training/gen/ai/GenAiTrainingApplication.java
@@ -4,12 +4,15 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
 
+/**
+ * SpringBoot Application main class of the Gen-AI training project.
+ */
 @SpringBootApplication
 @PropertySource("classpath:/config/application.properties")
 public class GenAiTrainingApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(GenAiTrainingApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(GenAiTrainingApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/epam/training/gen/ai/configuration/ClientOpenAiProperties.java
+++ b/src/main/java/com/epam/training/gen/ai/configuration/ClientOpenAiProperties.java
@@ -1,0 +1,14 @@
+package com.epam.training.gen.ai.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Record to load the Client OpenAI properties.
+ */
+@ConfigurationProperties()
+public record ClientOpenAiProperties(
+        String clientOpenAiKey,
+        String clientOpenAiEndpoint,
+        String clientOpenAiDeploymentName,
+        double genAiTemperature) {
+}

--- a/src/main/java/com/epam/training/gen/ai/configuration/OpenAIConfiguration.java
+++ b/src/main/java/com/epam/training/gen/ai/configuration/OpenAIConfiguration.java
@@ -1,0 +1,36 @@
+package com.epam.training.gen.ai.configuration;
+
+import com.azure.ai.openai.OpenAIAsyncClient;
+import com.azure.ai.openai.OpenAIClientBuilder;
+import com.azure.core.credential.AzureKeyCredential;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class for setting up Azure OpenAI Async Client bean.
+ * <p>
+ * This configuration defines a bean that provides an asynchronous client
+ * for interacting with the Azure OpenAI Service. It uses the Azure Key
+ * Credential for authentication and connects to a specified endpoint.
+ */
+@Configuration
+@EnableConfigurationProperties(ClientOpenAiProperties.class)
+@RequiredArgsConstructor
+public class OpenAIConfiguration {
+    private final ClientOpenAiProperties clientOpenAiProperties;
+
+    /**
+     * Creates an {@link OpenAIAsyncClient} bean for interacting with Azure OpenAI Service asynchronously.
+     *
+     * @return an instance of {@link OpenAIAsyncClient}
+     */
+    @Bean
+    public OpenAIAsyncClient openAIAsyncClient() {
+        return new OpenAIClientBuilder()
+                .credential(new AzureKeyCredential(clientOpenAiProperties.clientOpenAiKey()))
+                .endpoint(clientOpenAiProperties.clientOpenAiEndpoint())
+                .buildAsyncClient();
+    }
+}

--- a/src/main/java/com/epam/training/gen/ai/configuration/SemanticKernelConfiguration.java
+++ b/src/main/java/com/epam/training/gen/ai/configuration/SemanticKernelConfiguration.java
@@ -1,0 +1,66 @@
+package com.epam.training.gen.ai.configuration;
+
+import com.azure.ai.openai.OpenAIAsyncClient;
+import com.microsoft.semantickernel.Kernel;
+import com.microsoft.semantickernel.aiservices.openai.chatcompletion.OpenAIChatCompletion;
+import com.microsoft.semantickernel.orchestration.InvocationContext;
+import com.microsoft.semantickernel.orchestration.PromptExecutionSettings;
+import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class for setting up Semantic Kernel beans.
+ * <p>
+ * This configuration provides several beans necessary for the interaction with Azure OpenAI services.
+ * It defines beans for chat completion services, kernel instance, and invocation context settings.
+ */
+@Configuration
+@RequiredArgsConstructor
+public class SemanticKernelConfiguration {
+
+    private final ClientOpenAiProperties clientOpenAiProperties;
+
+    /**
+     * Generates a {@link ChatCompletionService} bean for handling chat completions.
+     *
+     * @param openAIAsyncClient to communicate with Azure OpenAI
+     * @return an instance of {@link ChatCompletionService}
+     */
+    @Bean
+    public ChatCompletionService chatCompletionService(OpenAIAsyncClient openAIAsyncClient) {
+        return OpenAIChatCompletion.builder()
+                .withModelId(clientOpenAiProperties.clientOpenAiDeploymentName())
+                .withOpenAIAsyncClient(openAIAsyncClient)
+                .build();
+    }
+
+    /**
+     * Generates a {@link Kernel} bean to manage AI services.
+     *
+     * @param chatCompletionService to use as service
+     * @return the {@link Kernel} instance
+     */
+    @Bean
+    public Kernel kernel(ChatCompletionService chatCompletionService) {
+        return Kernel.builder()
+                .withAIService(ChatCompletionService.class, chatCompletionService)
+                .build();
+    }
+
+    /**
+     * Generates a {@link InvocationContext} bean that adds additional settings like the Temperature or the model.
+     *
+     * @return an {@link InvocationContext} instance
+     */
+    @Bean
+    public InvocationContext invocationContext() {
+        return InvocationContext.builder()
+                .withPromptExecutionSettings(PromptExecutionSettings.builder()
+                        .withTemperature(clientOpenAiProperties.genAiTemperature())
+                        .withModelId(clientOpenAiProperties.clientOpenAiDeploymentName())
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/com/epam/training/gen/ai/controller/ChatBotController.java
+++ b/src/main/java/com/epam/training/gen/ai/controller/ChatBotController.java
@@ -1,0 +1,54 @@
+package com.epam.training.gen.ai.controller;
+
+import com.epam.training.gen.ai.model.ChatbotResponse;
+import com.epam.training.gen.ai.service.PromptService;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.MimeTypeUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * REST Controller to send prompt to the Azure OpenAI Assitant and get responses.
+ */
+@RestController
+@RequestMapping(path = "/api/chat-bot", produces = MimeTypeUtils.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+public class ChatBotController {
+
+    private final PromptService promptService;
+
+    /**
+     * Simple endpoint to send Azure OpenAI a user prompt.
+     *
+     * @param input the user prompt
+     * @return the OpenAI response
+     */
+    @GetMapping(value = "/simple-prompt")
+    public ChatbotResponse sendSimplePrompt(@RequestParam String input) {
+        validateInput(input);
+        return promptService.sendSimplePrompt(input);
+    }
+
+    /**
+     * Eendpoint to send Azure OpenAI a user prompt with history.
+     *
+     * @param input the user prompt
+     * @return the OpenAI response
+     */
+    @GetMapping(value = "/prompt-with-history")
+    public ChatbotResponse sendPromptWithHistory(@RequestParam String input) {
+        validateInput(input);
+        return promptService.sendPromptWithHistory(input);
+    }
+
+    private void validateInput(String input) {
+        if (StringUtils.isEmpty(input)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "'input' request parameter is mandatory");
+        }
+    }
+}

--- a/src/main/java/com/epam/training/gen/ai/model/ChatbotResponse.java
+++ b/src/main/java/com/epam/training/gen/ai/model/ChatbotResponse.java
@@ -1,0 +1,9 @@
+package com.epam.training.gen.ai.model;
+
+/**
+ * Model Record to handle the user response.
+ *
+ * @param response the Azure OpenAI Assistance response to the prompt
+ */
+public record ChatbotResponse(String response) {
+}

--- a/src/main/java/com/epam/training/gen/ai/service/PromptService.java
+++ b/src/main/java/com/epam/training/gen/ai/service/PromptService.java
@@ -1,0 +1,71 @@
+package com.epam.training.gen.ai.service;
+
+import com.epam.training.gen.ai.model.ChatbotResponse;
+import com.microsoft.semantickernel.Kernel;
+import com.microsoft.semantickernel.orchestration.InvocationContext;
+import com.microsoft.semantickernel.semanticfunctions.KernelFunction;
+import com.microsoft.semantickernel.semanticfunctions.KernelFunctionArguments;
+import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
+import com.microsoft.semantickernel.services.chatcompletion.ChatHistory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PromptService {
+    private final ChatCompletionService chatCompletionService;
+    private final Kernel kernel;
+    private final InvocationContext invocationContext;
+
+    /**
+     * Send a simple prompt to Azure OpenAI.
+     *
+     * @param userPrompt prompt send by user
+     * @return the response from the AI Assistant
+     */
+    public ChatbotResponse sendSimplePrompt(String userPrompt) {
+        var chatHistory = new ChatHistory();
+        chatHistory.addUserMessage(userPrompt);
+
+        var response = chatCompletionService.getChatMessageContentsAsync(chatHistory, kernel, invocationContext).block();
+        var message = response.stream()
+                .map(messageContent -> messageContent.getContent())
+                .collect(Collectors.joining("\n"));
+
+        return new ChatbotResponse(message);
+    }
+
+    /**
+     * Send a prompt with history to Azure OpenAI.
+     *
+     * @param userPrompt prompt send by user
+     * @return the response from the AI Assistant
+     */
+    public ChatbotResponse sendPromptWithHistory(String userPrompt) {
+        var chatHistory = new ChatHistory();
+        var response = kernel.invokeAsync(getKernelTemplate())
+                .withArguments(getKernelFunctionArguments(chatHistory, userPrompt)).block();
+
+        // Add messages to history
+        chatHistory.addUserMessage(userPrompt);
+        chatHistory.addAssistantMessage(response.getResult());
+
+        return new ChatbotResponse(response.getResult());
+    }
+
+    private KernelFunction<String> getKernelTemplate() {
+        return KernelFunction.<String>createFromPrompt("""
+                {{$chatHistory}}
+                <message role="user">{{$userPrompt}}</message>""").build();
+    }
+
+    private KernelFunctionArguments getKernelFunctionArguments(ChatHistory chatHistory, String userPrompt) {
+        return KernelFunctionArguments.builder()
+                .withVariable("chatHistory", chatHistory)
+                .withVariable("userPrompt", userPrompt)
+                .build();
+    }
+
+}

--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -1,0 +1,6 @@
+application-name=gen_ai_training
+client-openai-key=${OPEN_AI_KEY}
+client-openai-endpoint=${OPEN_AI_ENDPOINT}
+client-openai-deployment-name=${OPEN_AI_DEPLOYMENT_NAME}
+gen-ai-temperature=0.8
+server.error.include-message=ALWAYS


### PR DESCRIPTION
These changes adds the basic configurations to connect to Azure OpenAI. Includes the necessary properties, services, and controller to expose a REST API to communicate with the AI Assistant.

Module: 1

# Screenshots
![image](https://github.com/user-attachments/assets/cffe5f84-da38-40b2-8c4c-140cfcf5a74f)
